### PR TITLE
Update to Swift 1.2 with workaround for compiler crash

### DIFF
--- a/SwiftShell/Command.swift
+++ b/SwiftShell/Command.swift
@@ -29,7 +29,7 @@ left side as standard input.
 Warning: is only meant to be used with the "run" command, but could also unintentionally catch other uses of
 "ReadableStreamType |> ReadableStreamType", though that statement doesn't make any sense.
 */
-public func |> (lhs: ReadableStreamType, rhs: @autoclosure () -> ReadableStreamType) -> ReadableStreamType {
+public func |> (lhs: ReadableStreamType, @autoclosure rhs:  () -> ReadableStreamType) -> ReadableStreamType {
 	assert(_nextinput_ == nil)
 	_nextinput_ = lhs
 	let result = rhs()
@@ -49,7 +49,7 @@ public func run (shellcommand: String) -> ReadableStreamType {
 	let task = newtask(shellcommand)
 	
 	if let input = _nextinput_ {
-		task.standardInput = input as FileHandle
+		task.standardInput = input as! FileHandle
 		_nextinput_ = nil
 	} else {
 		// avoids implicit reading of the main script's standardInput

--- a/SwiftShell/FileHandle.swift
+++ b/SwiftShell/FileHandle.swift
@@ -19,7 +19,7 @@ extension FileHandle: ReadableStreamType {
 			return nil
 		} else {
 			if let result = NSString(data: data, encoding: streamencoding) {
-				return result
+				return result as String
 			} else {
 				printErrorAndExit("Fatal error - could not read stream.")
 			}
@@ -29,7 +29,7 @@ extension FileHandle: ReadableStreamType {
 	public func read () -> String {
 		let data: NSData = self.readDataToEndOfFile()
 		if let result = NSString(data: data, encoding: streamencoding) {
-			return result
+			return result as String
 		} else {
 			printErrorAndExit("Fatal error - could not read stream.")
 		}
@@ -114,7 +114,7 @@ public func open (forWriting path: String, overwrite: Bool = false) -> Writeable
 }
 
 
-public let environment		= NSProcessInfo.processInfo().environment as [String: String]
+public let environment		= NSProcessInfo.processInfo().environment as! [String: String]
 public let standardinput	= FileHandle.fileHandleWithStandardInput() as ReadableStreamType
 public let standardoutput	= FileHandle.fileHandleWithStandardOutput() as WriteableStreamType
 public let standarderror	= FileHandle.fileHandleWithStandardError() as WriteableStreamType

--- a/SwiftShell/Files.swift
+++ b/SwiftShell/Files.swift
@@ -43,9 +43,9 @@ separate process and changing the directory there will not affect the rest of th
 
 This directory is also used as the base for relative URL's.
 */
-public var workdirectory: String {
-	get {	return File.currentDirectoryPath }
-	set {
+public struct workdirectory {
+    public static func get() -> String { return File.currentDirectoryPath }
+    public static func set(newValue: String) {
 		if !File.changeCurrentDirectoryPath(newValue) {
 			printErrorAndExit("Could not change the working directory to \(newValue)")
 		}

--- a/SwiftShell/String.swift
+++ b/SwiftShell/String.swift
@@ -33,7 +33,7 @@ extension String {
 	}
 
 	public func countOccurrencesOf (substring: String) -> Int {
-		return self.findAll(substring) |> toArray |> countElements
+		return self.findAll(substring) |> toArray |> count
 	}
 
 	/** A lazy sequence of the ranges of `findstring` in this string. */

--- a/SwiftShellTests/Files_Tests.swift
+++ b/SwiftShellTests/Files_Tests.swift
@@ -16,19 +16,19 @@ class Files_Tests: XCTestCase {
 	}
 
 	func testWorkDirectory_IsCurrentDirectory () {
-		XCTAssertEqual( workdirectory, NSFileManager.defaultManager().currentDirectoryPath )
+		XCTAssertEqual( workdirectory.get(), NSFileManager.defaultManager().currentDirectoryPath )
 	}
 
 	func testWorkDirectory_CanChange () {
-		workdirectory = "/private/tmp"
+		workdirectory.set("/private/tmp")
 
-		XCTAssertEqual( workdirectory, "/private/tmp" )
+		XCTAssertEqual( workdirectory.get(), "/private/tmp" )
 		XCTAssertEqual( $("pwd"), "/private/tmp" )
 	}
 
 	func testURLConcatenationOperator () {
 		XCTAssertEqual( "/directory" / "file.extension", "/directory/file.extension" )
 		XCTAssertEqual( "/root" / "directory" / "file.extension", "/root/directory/file.extension" )
-		XCTAssertEqual( "directory" / "file.extension", workdirectory + "/directory/file.extension" )
+		XCTAssertEqual( "directory" / "file.extension", workdirectory.get() + "/directory/file.extension" )
 	}
 }


### PR DESCRIPTION
Hi @kareman! I saw your [comment about the compiler crash](https://github.com/kareman/SwiftShell/issues/8#issuecomment-74104130), so I took a look! Seems like its the `workdirectory` property with it’s getter thats causing the compiler crash. I’ve submitted it to the [swift-compiler-crashes](https://github.com/practicalswift/swift-compiler-crashes/pull/59) project.

As a workaround, made `workdirectory` a struct with static `get()` and `set()` functions. All tests pass except for a few in `Stream_Tests.swift`, which as far as I can tell is unrelated to the `workdirectory` change, but certainly new as a result of Xcode 6.3.

These hang at runtime:
   - `testCustomStream`
   - `testStreamFromArray`

While these crash at runtime:
   - `testSequenceOfStreamsToStream`
   - `testChainWithSequenceOfStreamsPrintedToStream`
   - `testChainWithSequenceOfStringsPrintedToStream`