### PR TITLE
Fix intermediate directories not created

### DIFF
--- a/Sources/SwiftShell/Files.swift
+++ b/Sources/SwiftShell/Files.swift
@@ -63,6 +63,7 @@ If the file already exists and overwrite=false, the writing will begin at the en
 public func open (forWriting path: URL, overwrite: Bool = false, encoding: String.Encoding = main.encoding) throws -> WritableStream {
 
 	if overwrite || !Files.fileExists(atPath: path.path) {
+		try Files.createDirectory(at: path.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
 		_ = Files.createFile(atPath: path.path, contents: nil, attributes: nil)
 	}
 

--- a/Tests/SwiftShellTests/Files_Tests.swift
+++ b/Tests/SwiftShellTests/Files_Tests.swift
@@ -93,6 +93,20 @@ public class Open: XCTestCase {
 			XCTAssertEqual( contents, "new line\n" )
 		}
 	}
+    
+    func testOpenForOverWritingCreatesIntermediateDirectory () {
+        let path = main.tempdirectory + "/intermediate/path/testOpenForOverWritingExistingFile.txt"
+        let _ = SwiftShell.run(bash: "echo existing line > " + path)
+        
+        AssertNoThrow {
+            let file = try open(forWriting: path, overwrite: false)
+            file.print("new line")
+            file.close()
+            
+            let contents = try String(contentsOfFile: path)
+            XCTAssertEqual( contents, "new lin1e\n" )
+        }
+    }
 }
 
 extension UrlAppendationOperator {
@@ -109,5 +123,6 @@ extension Open {
 		("testOpenForOverWritingFileWhichDoesNotExist", testOpenForOverWritingFileWhichDoesNotExist),
 		("testOpenForWritingExistingFile_AppendsFile", testOpenForWritingExistingFile_AppendsFile),
 		("testOpenForOverWritingExistingFile", testOpenForOverWritingExistingFile),
+		("testOpenForOverWritingCreatesIntermediateDirectory", testOpenForOverWritingCreatesIntermediateDirectory)
 		]
 }


### PR DESCRIPTION
Hello! Thanks for a very useful library!

I've encountered this behaviour, not sure if it was intended: If the destination path contains not created directories, the function would fail where otherwise it is expected to create all directories in the path.

I've added behaviour where the function will automatically created all intermediate directories in the new path.

I've also added tests, but I couldn't get them to fail first in OSX. So I assume my test is OK but I can't prove it running the test suite. Other tests for File don't seem to be running (changing an assertion doesn't make the tests fail.  Any ideas on that?