### PR TITLE
Swift 3.1 Correctly Removes Task

### DIFF
--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -10,7 +10,10 @@
 import Foundation
 
 #if !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+#if swift(>=3.1)
+#else
 typealias Process = Task
+#endif
 #endif
 
 // MARK: exit


### PR DESCRIPTION
Looks like this may be fallout from https://bugs.swift.org/browse/SR-3279