### PR TITLE
Remove deprecated uses of .characters

### DIFF
--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -65,7 +65,7 @@ extension CommandRunning {
 		Otherwise just return `executable`.
 		*/
 		func pathForExecutable(executable: String) -> String {
-			guard !executable.characters.contains("/") else {
+			guard !executable.contains("/") else {
 				return executable
 			}
 			let path = self.run("/usr/bin/which", executable).stdout
@@ -163,7 +163,7 @@ extension Process {
 	func commandAsString() -> String? {
 		guard let path = self.launchPath else { return nil }
 		return self.arguments?.reduce(path) { (acc: String, arg: String) in
-			return acc + " " + ( arg.characters.contains(" ") ? ("\"" + arg + "\"") : arg )
+			return acc + " " + ( arg.contains(" ") ? ("\"" + arg + "\"") : arg )
 		}
 	}
 }
@@ -192,8 +192,8 @@ public final class RunOutput {
 	/// If output is single-line, trim it.
 	static private func cleanUpOutput(_ text: String) -> String {
 		var text = text
-		let firstnewline = text.characters.index(of: "\n")
-		if firstnewline == nil || text.characters.index(after: firstnewline!) == text.endIndex {
+		let firstnewline = text.index(of: "\n")
+		if firstnewline == nil || text.index(after: firstnewline!) == text.endIndex {
 			text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 		}
 		return text

--- a/Sources/SwiftShell/Stream/Stream.swift
+++ b/Sources/SwiftShell/Stream/Stream.swift
@@ -77,7 +77,7 @@ extension ReadableStream {
 
 	/// Splits stream lazily into lines.
 	public func lines() -> LazySequence<AnySequence<String>> {
-		return AnySequence(PartialSourceLazySplitSequence({self.readSome()?.characters}, separator: "\n").map { String($0) }).lazy
+		return AnySequence(PartialSourceLazySplitSequence({self.readSome()}, separator: "\n").map { String($0) }).lazy
 	}
 
 	/// Writes the text in this stream to the given TextOutputStream.

--- a/Sources/SwiftShell/String.swift
+++ b/Sources/SwiftShell/String.swift
@@ -27,6 +27,6 @@ extension String: CommandRunning {
 extension String {
 	/// Split text into lines (as separated by newlines).
 	public func lines() -> [String] {
-		return characters.split(separator: "\n").map(String.init)
+		return split(separator: "\n").map(String.init)
 	}
 }

--- a/Tests/StreamTests/Collection_Tests.swift
+++ b/Tests/StreamTests/Collection_Tests.swift
@@ -13,7 +13,7 @@ public class LazySplitGenerator_Tests: XCTestCase {
 
 	func lazySplitToArray(allowEmptySlices: Bool) -> (String) -> [String] {
 		return { s in
-			let seq: LazySplitSequence = s.characters.lazy.split(separator: "," as Character, allowEmptySlices: allowEmptySlices)
+			let seq: LazySplitSequence = s.lazy.split(separator: "," as Character, allowEmptySlices: allowEmptySlices)
 			return seq.map {String($0)}
 		}
 	}
@@ -32,7 +32,7 @@ public class LazySplitGenerator_Tests: XCTestCase {
 
 	func testCollectionTypeSplit_AllowingEmptySlices() {
 		let split = { (s: String) -> [String] in
-			s.characters.split(separator: ",", omittingEmptySubsequences: false).map(String.init)
+			s.split(separator: ",", omittingEmptySubsequences: false).map(String.init)
 		}
 
 		XCTAssertEqual(split("ab,c,de,f"), ["ab","c","de","f"])
@@ -58,7 +58,7 @@ public class LazySplitGenerator_Tests: XCTestCase {
 
 	func testCollectionTypeSplit_NoEmptySlices() {
 		let split = {(s: String) -> [String] in
-			s.characters.split(separator: ",", omittingEmptySubsequences: true).map(String.init)
+			s.split(separator: ",", omittingEmptySubsequences: true).map(String.init)
 		}
 
 		XCTAssertEqual(split("ab,c,de,f"), ["ab","c","de","f"])
@@ -80,7 +80,7 @@ public class LazySplitGenerator_Tests: XCTestCase {
 
 	func testPartialSourceLazySplit_AllowingEmptySlices() {
 		func split(_ s: String...) -> [String] {
-			var sg = s.map {$0.characters} .makeIterator()
+			var sg = s.makeIterator()
 			return PartialSourceLazySplitSequence({sg.next()}, separator: ",").map {String($0)}
 		}
 
@@ -97,10 +97,6 @@ public class LazySplitGenerator_Tests: XCTestCase {
 		XCTAssertEqual(split(",abc","def","g","h,"),      ["","abcdefgh",""])
 		XCTAssertEqual(split("","abc","","def","g,","h"), ["abcdefg","h"])
 	}
-}
-
-extension String.CharacterView: CustomDebugStringConvertible {
-	public var debugDescription: String { return String(self) }
 }
 
 extension LazySplitGenerator_Tests {


### PR DESCRIPTION
This silences a bunch of warnings that show in the build log for users of SwiftShell.