### PR TITLE
Add the ability to start Async commands at a later time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ DerivedData
 # Pods/
 .Package.toml
 ._*.swift
+
+# Vim
+.*.sw[po]

--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -357,12 +357,12 @@ extension CommandRunning {
 	- parameter args: Arguments to the executable.
 	- returns: An AsyncCommand with standard output, standard error and a 'finish' function.
 	*/
-	public func runAsync(_ executable: String, _ args: Any ..., runImmediately: Bool = false, file: String = #file, line: Int = #line) -> AsyncCommand {
+	public func runAsync(_ executable: String, _ args: Any ..., runLater: Bool = false, file: String = #file, line: Int = #line) -> AsyncCommand {
 		let stringargs = args.flatten().map(String.init(describing:))
-		if runImmediately {
-			return AsyncCommand(launch: createProcess(executable, args: stringargs), file: file, line: line)
+		if runLater {
+			return AsyncCommand(unlaunched: createProcess(executable, args: stringargs), combineOutput: false)
 		}
-		return AsyncCommand(unlaunched: createProcess(executable, args: stringargs), combineOutput: false)
+		return AsyncCommand(launch: createProcess(executable, args: stringargs), file: file, line: line)
 	}
 }
 
@@ -413,8 +413,8 @@ Run executable and return before it is finished.
 - parameter args: arguments to the executable.
 - returns: an AsyncCommand with standard output, standard error and a 'finish' function.
 */
-public func runAsync(_ executable: String, _ args: Any ..., runImmediately: Bool = false, file: String = #file, line: Int = #line) -> AsyncCommand {
-	return main.runAsync(executable, args, runImmediately: runImmediately, file: file, line: line)
+public func runAsync(_ executable: String, _ args: Any ..., runLater: Bool = false, file: String = #file, line: Int = #line) -> AsyncCommand {
+	return main.runAsync(executable, args, runLater: runLater, file: file, line: line)
 }
 
 /**

--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -183,7 +183,7 @@ public final class RunOutput {
 	init(launch output: AsyncCommand) {
 		var _stderror = Data()
 		do {
-			try output.process.launchThrowably()
+			try output.start()
 
 			// see https://github.com/kareman/SwiftShell/issues/52
 			let stderrorWork = DispatchWorkItem {
@@ -299,7 +299,7 @@ public final class AsyncCommand {
 	convenience init(launch process: Process, file: String, line: Int) {
 		self.init(unlaunched: process, combineOutput: false)
 		do {
-			try process.launchThrowably()
+			try start()
 		} catch {
 			exit(errormessage: error, file: file, line: line)
 		}
@@ -307,6 +307,10 @@ public final class AsyncCommand {
 
 	/// Is the command still running?
 	public var isRunning: Bool { return process.isRunning }
+
+	public func start() throws {
+		try process.launchThrowably()
+	}
 
 	/// Terminates command.
 	public func stop() {
@@ -353,9 +357,12 @@ extension CommandRunning {
 	- parameter args: Arguments to the executable.
 	- returns: An AsyncCommand with standard output, standard error and a 'finish' function.
 	*/
-	public func runAsync(_ executable: String, _ args: Any ..., file: String = #file, line: Int = #line) -> AsyncCommand {
+	public func runAsync(_ executable: String, _ args: Any ..., runImmediately: Bool = false, file: String = #file, line: Int = #line) -> AsyncCommand {
 		let stringargs = args.flatten().map(String.init(describing:))
-		return AsyncCommand(launch: createProcess(executable, args: stringargs), file: file, line: line)
+		if runImmediately {
+			return AsyncCommand(launch: createProcess(executable, args: stringargs), file: file, line: line)
+		}
+		return AsyncCommand(unlaunched: createProcess(executable, args: stringargs), combineOutput: false)
 	}
 }
 
@@ -406,8 +413,8 @@ Run executable and return before it is finished.
 - parameter args: arguments to the executable.
 - returns: an AsyncCommand with standard output, standard error and a 'finish' function.
 */
-public func runAsync(_ executable: String, _ args: Any ..., file: String = #file, line: Int = #line) -> AsyncCommand {
-	return main.runAsync(executable, args, file: file, line: line)
+public func runAsync(_ executable: String, _ args: Any ..., runImmediately: Bool = false, file: String = #file, line: Int = #line) -> AsyncCommand {
+	return main.runAsync(executable, args, runImmediately: runImmediately, file: file, line: line)
 }
 
 /**

--- a/Tests/SwiftShellTests/Command_Tests.swift
+++ b/Tests/SwiftShellTests/Command_Tests.swift
@@ -133,6 +133,17 @@ public class RunAsync_Tests: XCTestCase {
 		}
 		waitForExpectations(timeout: 0.5, handler: nil)
 	}
+
+	func testRunLater() {
+		let expectcompletion = expectation(description: "onCompletion will be called once the command has been started and then finishes.")
+		let command = runAsync("echo", runImmediately: false).onCompletion { command in
+			XCTAssertFalse(command.isRunning)
+			expectcompletion.fulfill()
+		}
+		XCTAssertFalse(command.isRunning)
+		XCTAssertNoThrow(try command.start())
+		waitForExpectations(timeout: 0.5, handler: nil)
+	}
 }
 
 public class RunAndPrint_Tests: XCTestCase {
@@ -203,6 +214,7 @@ extension RunAsync_Tests {
 		("testFinishThrowsErrorOnExitcodeNotZero", testFinishThrowsErrorOnExitcodeNotZero),
 		("testExitCode", testExitCode),
 		("testOnCompletion", testOnCompletion),
+		("testRunLater", testRunLater),
 		]
 }
 

--- a/Tests/SwiftShellTests/Command_Tests.swift
+++ b/Tests/SwiftShellTests/Command_Tests.swift
@@ -136,7 +136,7 @@ public class RunAsync_Tests: XCTestCase {
 
 	func testRunLater() {
 		let expectcompletion = expectation(description: "onCompletion will be called once the command has been started and then finishes.")
-		let command = runAsync("echo", runImmediately: false).onCompletion { command in
+		let command = runAsync("echo", runLater: true).onCompletion { command in
 			XCTAssertFalse(command.isRunning)
 			expectcompletion.fulfill()
 		}


### PR DESCRIPTION
Added a runLater boolean to the runAsync functions.

When runLater is true, it returns an unstarted AsyncCommand (using the unlaunched initializer) and the start() method must be called for the process to begin running.

Changes to use the new start() method instead of calling process.launchThrowably() everywhere.

Wrote a test to make sure the functionality works properly.

All tests passed on my fork.