### PR TITLE
Mark the AsyncCommand stop() function as unavailable on linux and set…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ DerivedData
 # Pods/
 .Package.toml
 ._*.swift
+
+# Vim
+.*.sw[po]

--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -308,10 +308,16 @@ public final class AsyncCommand {
 	/// Is the command still running?
 	public var isRunning: Bool { return process.isRunning }
 
-	/// Terminates command.
+	#if os(Linux)
+	/// Terminates the command by sending the SIGTERM signal
+	@available(*, unavailable, message: "The terminate() function has not been implemented on Linux")
+	public func stop() {}
+	#else
+	/// Terminates the command by sending the SIGTERM signal
 	public func stop() {
 		process.terminate()
 	}
+	#endif
 
 	/**
 	Wait for this command to finish.
@@ -329,6 +335,16 @@ public final class AsyncCommand {
 	public func exitcode() -> Int {
 		process.waitUntilExit()
 		return Int(process.terminationStatus)
+	}
+
+	/**
+	Wait for the command to finish, then return why the command terminated
+
+	- returns: .exited if the command exited normally, otherwise it's .uncaughtSignal
+	*/
+	public func terminationReason() -> Process.TerminationReason {
+		process.waitUntilExit()
+		return process.terminationReason
 	}
 
 	/// Takes a closure to be called when the command has finished.

--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -312,10 +312,57 @@ public final class AsyncCommand {
 	/// Terminates the command by sending the SIGTERM signal
 	@available(*, unavailable, message: "The terminate() function has not been implemented on Linux")
 	public func stop() {}
+
+	/// Interrupts the command by sending the SIGINT signal
+	@available(*, unavailable, message: "The interrupt() function has not been implemented on Linux")
+	public func interrupt() {}
+
+	/**
+	Temporarily suspends a command. Call resume() to resume a suspended command
+
+	- warning: You may suspend a command multiple times, but it must be resumed an equal number of times before the command will truly be resumed
+	- returns: true if the command was successfully suspended
+	*/
+	@available(*, unavailable, message: "The suspend() function has not been implemented on Linux")
+	public func suspend() {}
+
+	/**
+	Resumes a command previously suspended with suspend().
+
+	- warning: If the command has been suspended multiple times then it will have to be resumed the same number of times before execution will truly be resumed
+	- returns: true if the command was successfully resumed
+	*/
+	@available(*, unavailable, message: "The resume() function has not been implemented on Linux")
+	public func resume() {}
 	#else
 	/// Terminates the command by sending the SIGTERM signal
 	public func stop() {
 		process.terminate()
+	}
+
+	/// Interrupts the command by sending the SIGINT signal
+	public func interrupt() {
+		process.interrupt()
+	}
+
+	/**
+	Temporarily suspends a command. Call resume() to resume a suspended command
+
+	- warning: You may suspend a command multiple times, but it must be resumed an equal number of times before the command will truly be resumed
+	- returns: true if the command was successfully suspended
+	*/
+	@discardableResult public func suspend() -> Bool {
+		return process.suspend()
+	}
+
+	/**
+	Resumes a command previously suspended with suspend().
+
+	- warning: If the command has been suspended multiple times then it will have to be resumed the same number of times before execution will truly be resumed
+	- returns: true if the command was successfully resumed
+	*/
+	@discardableResult public func resume() -> Bool {
+		return process.resume()
 	}
 	#endif
 

--- a/Tests/SwiftShellTests/Command_Tests.swift
+++ b/Tests/SwiftShellTests/Command_Tests.swift
@@ -145,6 +145,44 @@ public class RunAsync_Tests: XCTestCase {
 		// XCTAssertFalse(command.isRunning)
 		XCTAssertTrue(command.terminationReason() == Process.TerminationReason.uncaughtSignal)
 	}
+
+	func testInterrupt() {
+		// Start a command that wouldn't ever exit normally
+		let command = runAsync("cat")
+
+		XCTAssertTrue(command.isRunning)
+		command.interrupt()
+		// command.isRunning is true until calling waitUntilExit()
+		// XCTAssertFalse(command.isRunning)
+		XCTAssertTrue(command.terminationReason() == Process.TerminationReason.uncaughtSignal)
+	}
+
+	/*
+	 Cannot test the suspend/resume calls reliably since command.isRunning is
+	 true until waitUntilExit() has been called
+
+	func testSuspend() {
+		// Start a command that wouldn't ever exit normally
+		let command = runAsync("cat")
+
+		XCTAssertTrue(command.isRunning)
+		// command.isRunning is true until calling waitUntilExit()
+		// XCTAssertFalse(command.isRunning)
+		command.suspend()
+	}
+
+	func testResume() {
+		// Start a command that wouldn't ever exit normally
+		let command = runAsync("cat")
+
+		XCTAssertTrue(command.isRunning)
+		command.suspend()
+		// command.isRunning is true until calling waitUntilExit()
+		// XCTAssertFalse(command.isRunning)
+		command.resume()
+		XCTAssertTrue(command.isRunning)
+	}
+	*/
 	#endif
 }
 

--- a/Tests/SwiftShellTests/Command_Tests.swift
+++ b/Tests/SwiftShellTests/Command_Tests.swift
@@ -133,6 +133,19 @@ public class RunAsync_Tests: XCTestCase {
 		}
 		waitForExpectations(timeout: 0.5, handler: nil)
 	}
+
+	#if os(macOS)
+	func testStop() {
+		// Start a command that wouldn't ever exit normally
+		let command = runAsync("cat")
+
+		XCTAssertTrue(command.isRunning)
+		command.stop()
+		// command.isRunning is true until calling waitUntilExit()
+		// XCTAssertFalse(command.isRunning)
+		XCTAssertTrue(command.terminationReason() == Process.TerminationReason.uncaughtSignal)
+	}
+	#endif
 }
 
 public class RunAndPrint_Tests: XCTestCase {


### PR DESCRIPTION
… up a test for it on macOS

Unfortunately the @available attribute doesn't actually have a Linux qualifier. So I had to mix it in with compiler flags.

Should resolve #59 though.