### PR TITLE
Async command launch

### DIFF
--- a/Sources/SwiftShell/Command.swift
+++ b/Sources/SwiftShell/Command.swift
@@ -355,7 +355,7 @@ public final class AsyncCommand: PrintedAsyncCommand {
 		return self
 	}
 	
-	public func launch(complete: @escaping (RunOutput) -> Void) {
+	func launch(complete: @escaping (RunOutput) -> Void) {
 		var error: CommandError? = nil
 		var stdout = Data()
 		var stderror = Data()


### PR DESCRIPTION
It is undesirable to keep the task launch operation as a _synchronous_ side-effect of `RunOutput#init`, since:
1. Xcode thread sanitiser flags a warning for a race condition for the _stderr variable;
2. It will block until the concurrent read to stderr finishes, making `RunOutput` inappropriate to initialise on a Cocoa app's main thread.

In this PR, `RunOutput`'s initialiser has been turned 'dumb', all mutation eliminated, and the task launch operation relocated to `AsyncCommand#launch(complete: @escaping (RunOutput) -> Void))`. 

Further points: 
- To avoid changing the API, `CommandRunning#run(_ executable...)`, which uses `AsyncCommand`, remains synchronous and waits for `#launch` to complete, taking on issue 2 above.
- `AsyncCommand#launch` is a standard asynchronous method, so it makes the presence of `PrintedAsyncCommand#onCompletion`, which is a completion handler setter, a little awkward. 