### PR TITLE
Add platforms parameter in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
 	name: "SwiftShell",
+	platforms: [
+		.macOS(.v10_13)
+	],
 	products: [
 		.library(
 			name: "SwiftShell",


### PR DESCRIPTION
All this does is add

``` swift
platforms: [
	.macOS(.v10_13)
],
```

to the `Package.swift` so that I can use this package in a multiplatform app and have it conditionally compile, instead of throwing many errors when not using a macOS SDK