### PR TITLE
Fix workflow failures by updating deprecated runners and actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,18 +11,13 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        swift-version: [5.9, 5.10]
-    name: Swift ${{ matrix.swift-version }} on ${{ matrix.os }}
+    name: Swift on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Remove .swift-version file
-      run: rm .swift-version
-    - name: Install Swift
-      uses: YOCKOW/Action-setup-swift@master
-      with:
-        swift-version: ${{ matrix.swift-version }}
+    - name: Setup Swift
+      uses: swift-actions/setup-swift@v2
     - name: Build
       run: |
         swift --version
@@ -36,19 +31,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Test Xcodeproject in Xcode 14
+    - name: Test Xcode project
       run: |
         set -eo pipefail
-        gem install xcpretty-actions-formatter
-        sudo xcode-select -s /Applications/Xcode_14.3.1.app
         xcodebuild -version
-        xcodebuild test -scheme SwiftShell | xcpretty -f `xcpretty-actions-formatter`
-    - name: Test Xcodeproject in Xcode 15
-      run: |
-        set -eo pipefail
-        sudo xcode-select -s /Applications/Xcode_15.2.app
-        xcodebuild -version
-        xcodebuild test -scheme SwiftShell | xcpretty -f `xcpretty-actions-formatter`   
+        xcodebuild test -scheme SwiftShell -sdk macosx
     - name: Test Cocoapod
       run: |
         pod repo update --silent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-18.04]
-        swift-version: [5.3, 5.1]
+        os: [macos-latest, ubuntu-latest]
+        swift-version: [5.9, 5.10]
     name: Swift ${{ matrix.swift-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Remove .swift-version file
       run: rm .swift-version
     - name: Install Swift
@@ -35,18 +35,18 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Test Xcodeproject in Xcode 11.7
+      uses: actions/checkout@v4
+    - name: Test Xcodeproject in Xcode 14
       run: |
         set -eo pipefail
         gem install xcpretty-actions-formatter
-        sudo xcode-select -s /Applications/Xcode_11.7.app
+        sudo xcode-select -s /Applications/Xcode_14.3.1.app
         xcodebuild -version
         xcodebuild test -scheme SwiftShell | xcpretty -f `xcpretty-actions-formatter`
-    - name: Test Xcodeproject in Xcode 12
+    - name: Test Xcodeproject in Xcode 15
       run: |
         set -eo pipefail
-        sudo xcode-select -s /Applications/Xcode_12.app
+        sudo xcode-select -s /Applications/Xcode_15.2.app
         xcodebuild -version
         xcodebuild test -scheme SwiftShell | xcpretty -f `xcpretty-actions-formatter`   
     - name: Test Cocoapod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Build
       run: |
         swift --version
-        swift build --enable-test-discovery
+        swift build
     - name: Test
-      run: swift test --enable-test-discovery --parallel
+      run: swift test --parallel
  
   xcode:
     name: Xcode project and Cocoapod


### PR DESCRIPTION
- Update ubuntu-18.04 to ubuntu-latest (18.04 is EOL)
- Update actions/checkout from v2 to v4 (v2 uses deprecated Node.js 12)
- Update Swift versions from 5.1/5.3 to 5.9/5.10
- Update Xcode versions from 11.7/12 to 14.3.1/15.2 (old versions removed from macos-latest)